### PR TITLE
fix: use secret for values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .direnv
 *.pyc
+.DS_Store

--- a/plugins/lookup/helm_values.py
+++ b/plugins/lookup/helm_values.py
@@ -2,26 +2,35 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from ansible.plugins.lookup import LookupBase
-from ansible.plugins.filter.core import combine, to_nice_yaml
+from ansible.plugins.filter.core import to_nice_yaml
 from ansible.errors import AnsibleLookupError
 
 DOCUMENTATION = """
 name: helm_values
 short_description: Lookup and merge helm values for a component
 description:
-  - Looks up base and override helm values for a single component
-  - Merges them using combine(recursive=True) and formats as YAML
+  - Looks up and merges helm values from multiple sources
+  - Handles nullification of missing values during updates
+  - Replaces null values with defaults
   - Expects variables named _<component>_helm_values and <component>_helm_values
 options:
   _terms:
-    description: Component name to lookup helm values for
+    description: |
+      List of arguments:
+      1. Component name to lookup helm values for
+      2. Current values from existing Helm release (optional)
     required: true
-    type: str
+    type: list
 """
 
 EXAMPLES = """
-- ansible.builtin.debug:
+# Basic usage for initial deployment
+- debug:
     msg: "{{ lookup('atmosphere.common.helm_values', 'metrics_server') }}"
+
+# Usage during update with current values
+- debug:
+    msg: "{{ lookup('atmosphere.common.helm_values', 'metrics_server', helm_info.values) }}"
 """
 
 RETURN = """
@@ -32,13 +41,67 @@ _value:
 
 
 class LookupModule(LookupBase):
+    def _nullify_missing_values(self, base, updated):
+        """
+        Recursively marks missing values as None when they exist in base but not in updated
+        """
+        if not isinstance(base, dict) or not isinstance(updated, dict):
+            return updated
+
+        result = {}
+        # First handle all keys from base
+        for key in base:
+            if key not in updated:
+                result[key] = None
+            else:
+                if isinstance(base[key], dict):
+                    if key in updated and isinstance(updated[key], dict):
+                        # Recursively handle nested dictionaries
+                        result[key] = self._nullify_missing_values(base[key], updated[key])
+                    else:
+                        # If the structure changed (dict -> non-dict), keep the update
+                        result[key] = updated[key]
+                else:
+                    result[key] = updated[key]
+
+        # Then add any new keys from updated that weren't in base
+        for key in updated:
+            if key not in base:
+                result[key] = updated[key]
+
+        return result
+
+    def _merge_replace_nulls(self, base, fallback):
+        """
+        Recursively replaces None values in base with values from fallback
+        """
+        if not isinstance(base, dict) or not isinstance(fallback, dict):
+            return fallback if base is None else base
+
+        result = {}
+        all_keys = set(base.keys()) | set(fallback.keys())
+
+        for key in all_keys:
+            base_val = base.get(key)
+            fallback_val = fallback.get(key)
+
+            if isinstance(base_val, dict) and isinstance(fallback_val, dict):
+                result[key] = self._merge_replace_nulls(base_val, fallback_val)
+            elif base_val is None and fallback_val is not None:
+                result[key] = fallback_val
+            else:
+                result[key] = base_val
+
+        return result
+
     def run(self, terms, variables=None, **kwargs):
         """
-        Look up and merge helm values for a single component
+        Look up and merge helm values for a component
 
         Args:
-            terms: List containing single component name
+            terms: List containing component name and optionally current values
             variables: Template variables context
+            **kwargs: Additional arguments
 
         Returns:
             List with single merged YAML string (Ansible lookup convention)
@@ -46,41 +109,47 @@ class LookupModule(LookupBase):
         if variables is None:
             variables = {}
 
-        if len(terms) != 1:
+        if not terms or len(terms) > 2:
             raise AnsibleLookupError(
-                "helm_values lookup expects exactly one component name"
+                "helm_values lookup expects one or two arguments: component_name, [current_values]"
             )
 
         component_name = terms[0]
+        current_values = terms[1] if len(terms) > 1 else {}
 
         try:
-            # Look up base values: _<component_name>_helm_values
+            # Get base defaults (_metrics_server_helm_values)
             base_var_name = f"_{component_name}_helm_values"
             base_values_raw = variables.get(base_var_name)
-
             if base_values_raw is None:
-                raise AnsibleLookupError(
-                    f"Base values variable '{base_var_name}' not found for "
-                    f"component '{component_name}'"
-                )
+                raise AnsibleLookupError(f"Base values variable '{base_var_name}' not found")
+            base_defaults = self._templar.template(base_values_raw)
 
-            # Template the base values
-            base_values = self._templar.template(base_values_raw)
-
-            # Look up override values: <component_name>_helm_values (optional)
+            # Get user overrides (metrics_server_helm_values)
             override_var_name = f"{component_name}_helm_values"
-            overrides_raw = variables.get(override_var_name, {})
+            user_overrides = self._templar.template(
+                variables.get(override_var_name, {})
+            )
 
-            # Template the override values
-            overrides = self._templar.template(overrides_raw)
+            if current_values:
+                # First, nullify keys that exist in current_values but not in user_overrides
+                nullified_current = self._nullify_missing_values(current_values, user_overrides)
+                
+                # Then, nullify keys that exist in base_defaults but not in user_overrides
+                nullified_from_base = self._nullify_missing_values(base_defaults, user_overrides)
+                
+                # Merge the two nullified sets
+                merged_nullified = self._merge_replace_nulls(nullified_current, nullified_from_base)
+                
+                # Finally, replace remaining nulls with base defaults
+                result = self._merge_replace_nulls(merged_nullified, base_defaults)
+            else:
+                # For initial deployment, compare against base_defaults and merge
+                nullified_overrides = self._nullify_missing_values(base_defaults, user_overrides)
+                result = self._merge_replace_nulls(nullified_overrides, base_defaults)
 
-            # Merge using built-in combine filter
-            merged = combine(base_values, overrides, recursive=True)
-
-            # Format as YAML using built-in to_nice_yaml filter
-            yaml_output = to_nice_yaml(merged, indent=2)
-
-            # Return as single-item list (Ansible lookup convention)
+            # Format as YAML
+            yaml_output = to_nice_yaml(result, indent=2)
             return [yaml_output]
 
         except Exception as e:

--- a/plugins/lookup/helm_values.py
+++ b/plugins/lookup/helm_values.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2025 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from ansible.plugins.lookup import LookupBase
+from ansible.plugins.filter.core import combine, to_nice_yaml
+from ansible.errors import AnsibleLookupError
+
+DOCUMENTATION = """
+name: helm_values
+short_description: Lookup and merge helm values for a component
+description:
+  - Looks up base and override helm values for a single component
+  - Merges them using combine(recursive=True) and formats as YAML
+  - Expects variables named _<component>_helm_values and <component>_helm_values
+options:
+  _terms:
+    description: Component name to lookup helm values for
+    required: true
+    type: str
+"""
+
+EXAMPLES = """
+- ansible.builtin.debug:
+    msg: "{{ lookup('atmosphere.common.helm_values', 'metrics_server') }}"
+"""
+
+RETURN = """
+_value:
+  description: Merged helm values as YAML string
+  type: str
+"""
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables=None, **kwargs):
+        """
+        Look up and merge helm values for a single component
+
+        Args:
+            terms: List containing single component name
+            variables: Template variables context
+
+        Returns:
+            List with single merged YAML string (Ansible lookup convention)
+        """
+        if variables is None:
+            variables = {}
+
+        if len(terms) != 1:
+            raise AnsibleLookupError(
+                "helm_values lookup expects exactly one component name"
+            )
+
+        component_name = terms[0]
+
+        try:
+            # Look up base values: _<component_name>_helm_values
+            base_var_name = f"_{component_name}_helm_values"
+            base_values_raw = variables.get(base_var_name)
+
+            if base_values_raw is None:
+                raise AnsibleLookupError(
+                    f"Base values variable '{base_var_name}' not found for "
+                    f"component '{component_name}'"
+                )
+
+            # Template the base values
+            base_values = self._templar.template(base_values_raw)
+
+            # Look up override values: <component_name>_helm_values (optional)
+            override_var_name = f"{component_name}_helm_values"
+            overrides_raw = variables.get(override_var_name, {})
+
+            # Template the override values
+            overrides = self._templar.template(overrides_raw)
+
+            # Merge using built-in combine filter
+            merged = combine(base_values, overrides, recursive=True)
+
+            # Format as YAML using built-in to_nice_yaml filter
+            yaml_output = to_nice_yaml(merged, indent=2)
+
+            # Return as single-item list (Ansible lookup convention)
+            return [yaml_output]
+
+        except Exception as e:
+            raise AnsibleLookupError(
+                f"Failed to lookup helm values for component '{component_name}': {str(e)}"
+            )

--- a/roles/cert_manager/defaults/main.yaml
+++ b/roles/cert_manager/defaults/main.yaml
@@ -8,6 +8,7 @@ cert_manager_helm_chart_version: 1.17.2
 
 cert_manager_helm_release_namespace: cert-manager
 cert_manager_helm_release_name: cert-manager
+cert_manager_helm_release_secret_name: "{{ cert_manager_helm_release_name }}-values"
 
 cert_manager_helm_values: {}
 cert_manager_node_selector: {}

--- a/roles/cert_manager/tasks/main.yaml
+++ b/roles/cert_manager/tasks/main.yaml
@@ -1,6 +1,19 @@
 # Copyright (c) 2025 VEXXHOST, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+- name: Get current Helm release info
+  run_once: true
+  kubernetes.core.helm_info:
+    name: "{{ cert_manager_helm_release_name }}"
+    namespace: "{{ cert_manager_helm_release_namespace }}"
+    release_state: all
+  register: cert_manager_helm_info
+
+- name: Set final version for chart values
+  run_once: true
+  ansible.builtin.set_fact:
+    cert_manager_final_helm_values: "{{ lookup('atmosphere.common.helm_values', 'cert_manager', (cert_manager_helm_info.status['values'] | default({}))) }}" # noqa: yaml[line-length]
+
 - name: Install "cert-manager"
   run_once: true
   kubernetes.core.k8s:
@@ -13,15 +26,6 @@
         metadata:
           name: "{{ cert_manager_helm_release_namespace }}"
 
-      - apiVersion: source.toolkit.fluxcd.io/v1
-        kind: HelmRepository
-        metadata:
-          name: "{{ cert_manager_helm_repository_name }}"
-          namespace: "{{ cert_manager_helm_release_namespace }}"
-        spec:
-          interval: 5m
-          url: "{{ cert_manager_helm_repository_url }}"
-
       - apiVersion: v1
         kind: Secret
         metadata:
@@ -29,7 +33,16 @@
           namespace: "{{ cert_manager_helm_release_namespace }}"
         type: Opaque
         stringData:
-          values.yaml: "{{ lookup('atmosphere.common.helm_values', 'cert_manager') }}"
+          values.yaml: "{{ cert_manager_final_helm_values }}"
+
+      - apiVersion: source.toolkit.fluxcd.io/v1
+        kind: HelmRepository
+        metadata:
+          name: "{{ cert_manager_helm_repository_name }}"
+          namespace: "{{ cert_manager_helm_release_namespace }}"
+        spec:
+          interval: 60m
+          url: "{{ cert_manager_helm_repository_url }}"
 
       - apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
@@ -37,7 +50,7 @@
           name: "{{ cert_manager_helm_release_name }}"
           namespace: "{{ cert_manager_helm_release_namespace }}"
           annotations:
-            reconcile.fluxcd.io/requestedAt: "{{ lookup('atmosphere.common.helm_values', 'cert_manager') | checksum }}"
+            reconcile.fluxcd.io/requestedAt: "{{ cert_manager_final_helm_values | checksum }}"
         spec:
           interval: 10m
           releaseName: "{{ cert_manager_helm_release_name }}"

--- a/roles/cert_manager/tasks/main.yaml
+++ b/roles/cert_manager/tasks/main.yaml
@@ -22,11 +22,22 @@
           interval: 5m
           url: "{{ cert_manager_helm_repository_url }}"
 
+      - apiVersion: v1
+        kind: Secret
+        metadata:
+          name: "{{ cert_manager_helm_release_secret_name }}"
+          namespace: "{{ cert_manager_helm_release_namespace }}"
+        type: Opaque
+        stringData:
+          values.yaml: "{{ lookup('atmosphere.common.helm_values', 'cert_manager') }}"
+
       - apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: "{{ cert_manager_helm_release_name }}"
           namespace: "{{ cert_manager_helm_release_namespace }}"
+          annotations:
+            reconcile.fluxcd.io/requestedAt: "{{ lookup('atmosphere.common.helm_values', 'cert_manager') | checksum }}"
         spec:
           interval: 10m
           releaseName: "{{ cert_manager_helm_release_name }}"
@@ -37,4 +48,6 @@
               sourceRef:
                 kind: HelmRepository
                 name: "{{ cert_manager_helm_repository_name }}"
-          values: "{{ _cert_manager_helm_values | combine(cert_manager_helm_values, recursive=True) }}"
+          valuesFrom:
+            - kind: Secret
+              name: "{{ cert_manager_helm_release_secret_name }}"

--- a/roles/dellhw_exporter/defaults/main.yaml
+++ b/roles/dellhw_exporter/defaults/main.yaml
@@ -8,6 +8,7 @@ dellhw_exporter_helm_chart_version: 1.0.3
 
 dellhw_exporter_helm_release_namespace: monitoring
 dellhw_exporter_helm_release_name: prometheus-dellhw-exporter
+dellhw_exporter_helm_release_secret_name: "{{ dellhw_exporter_helm_release_name }}-values"
 
 dellhw_exporter_helm_values: {}
 

--- a/roles/dellhw_exporter/tasks/main.yaml
+++ b/roles/dellhw_exporter/tasks/main.yaml
@@ -1,7 +1,20 @@
 # Copyright (c) 2025 VEXXHOST, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-- name: Install "dellhw_exporter"
+- name: Get current Helm release info
+  run_once: true
+  kubernetes.core.helm_info:
+    name: "{{ dellhw_exporter_helm_release_name }}"
+    namespace: "{{ dellhw_exporter_helm_release_namespace }}"
+    release_state: all
+  register: dellhw_exporter_helm_info
+
+- name: Set final version for chart values
+  run_once: true
+  ansible.builtin.set_fact:
+    dellhw_exporter_final_helm_values: "{{ lookup('atmosphere.common.helm_values', 'dellhw_exporter', (dellhw_exporter_helm_info.status['values'] | default({}))) }}" # noqa: yaml[line-length]
+
+- name: Install "dellhw-exporter"
   run_once: true
   kubernetes.core.k8s:
     server_side_apply:
@@ -13,6 +26,15 @@
         metadata:
           name: "{{ dellhw_exporter_helm_release_namespace }}"
 
+      - apiVersion: v1
+        kind: Secret
+        metadata:
+          name: "{{ dellhw_exporter_helm_release_secret_name }}"
+          namespace: "{{ dellhw_exporter_helm_release_namespace }}"
+        type: Opaque
+        stringData:
+          values.yaml: "{{ dellhw_exporter_final_helm_values }}"
+
       - apiVersion: source.toolkit.fluxcd.io/v1
         kind: HelmRepository
         metadata:
@@ -22,22 +44,13 @@
           interval: 60m
           url: "{{ dellhw_exporter_helm_repository_url }}"
 
-      - apiVersion: v1
-        kind: Secret
-        metadata:
-          name: "{{ dellhw_exporter_helm_release_secret_name }}"
-          namespace: "{{ dellhw_exporter_helm_release_namespace }}"
-        type: Opaque
-        stringData:
-          values.yaml: "{{ lookup('atmosphere.common.helm_values', 'dellhw_exporter') }}"
-
       - apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: "{{ dellhw_exporter_helm_release_name }}"
           namespace: "{{ dellhw_exporter_helm_release_namespace }}"
           annotations:
-            reconcile.fluxcd.io/requestedAt: "{{ lookup('atmosphere.common.helm_values', 'dellhw_exporter') | checksum }}"
+            reconcile.fluxcd.io/requestedAt: "{{ dellhw_exporter_final_helm_values | checksum }}"
         spec:
           interval: 10m
           releaseName: "{{ dellhw_exporter_helm_release_name }}"

--- a/roles/dellhw_exporter/tasks/main.yaml
+++ b/roles/dellhw_exporter/tasks/main.yaml
@@ -22,11 +22,22 @@
           interval: 60m
           url: "{{ dellhw_exporter_helm_repository_url }}"
 
+      - apiVersion: v1
+        kind: Secret
+        metadata:
+          name: "{{ dellhw_exporter_helm_release_secret_name }}"
+          namespace: "{{ dellhw_exporter_helm_release_namespace }}"
+        type: Opaque
+        stringData:
+          values.yaml: "{{ lookup('atmosphere.common.helm_values', 'dellhw_exporter') }}"
+
       - apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: "{{ dellhw_exporter_helm_release_name }}"
           namespace: "{{ dellhw_exporter_helm_release_namespace }}"
+          annotations:
+            reconcile.fluxcd.io/requestedAt: "{{ lookup('atmosphere.common.helm_values', 'dellhw_exporter') | checksum }}"
         spec:
           interval: 10m
           releaseName: "{{ dellhw_exporter_helm_release_name }}"
@@ -37,4 +48,6 @@
               sourceRef:
                 kind: HelmRepository
                 name: "{{ dellhw_exporter_helm_repository_name }}"
-          values: "{{ _dellhw_exporter_helm_values | combine(dellhw_exporter_helm_values, recursive=True) }}"
+          valuesFrom:
+            - kind: Secret
+              name: "{{ dellhw_exporter_helm_release_secret_name }}"

--- a/roles/metrics_server/defaults/main.yaml
+++ b/roles/metrics_server/defaults/main.yaml
@@ -8,6 +8,7 @@ metrics_server_helm_chart_version: 3.12.2
 
 metrics_server_helm_release_namespace: kube-system
 metrics_server_helm_release_name: metrics-server
+metrics_server_helm_release_secret_name: "{{ metrics_server_helm_release_name }}-values"
 
 metrics_server_helm_values: {}
 

--- a/roles/metrics_server/tasks/main.yaml
+++ b/roles/metrics_server/tasks/main.yaml
@@ -1,6 +1,19 @@
 # Copyright (c) 2025 VEXXHOST, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+- name: Install "metrics-server" XXXX
+  run_once: true
+  kubernetes.core.k8s:
+    definition:
+      - apiVersion: v1
+        kind: Secret
+        metadata:
+          name: "{{ metrics_server_helm_release_secret_name }}"
+          namespace: "{{ metrics_server_helm_release_namespace }}"
+        type: Opaque
+        stringData:
+          values.yaml: "{{ lookup('atmosphere.common.helm_values', 'metrics_server') }}"
+
 - name: Install "metrics-server"
   run_once: true
   kubernetes.core.k8s:
@@ -22,15 +35,6 @@
           interval: 60m
           url: "{{ metrics_server_helm_repository_url }}"
 
-      - apiVersion: v1
-        kind: Secret
-        metadata:
-          name: "{{ metrics_server_helm_release_secret_name }}"
-          namespace: "{{ metrics_server_helm_release_namespace }}"
-        type: Opaque
-        stringData:
-          values.yaml: "{{ lookup('atmosphere.common.helm_values', 'metrics_server') }}"
-
       - apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
@@ -38,8 +42,10 @@
           namespace: "{{ metrics_server_helm_release_namespace }}"
           annotations:
             reconcile.fluxcd.io/requestedAt: "{{ lookup('atmosphere.common.helm_values', 'metrics_server') | checksum }}"
+            reconcile.fluxcd.io/forceAt: "{{ lookup('atmosphere.common.helm_values', 'metrics_server') | checksum }}"
         spec:
-          interval: 10m
+          interval: 5m
+          timeout: 5m
           releaseName: "{{ metrics_server_helm_release_name }}"
           chart:
             spec:

--- a/roles/metrics_server/tasks/main.yaml
+++ b/roles/metrics_server/tasks/main.yaml
@@ -1,18 +1,18 @@
 # Copyright (c) 2025 VEXXHOST, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-- name: Install "metrics-server" XXXX
+- name: Get current Helm release info
   run_once: true
-  kubernetes.core.k8s:
-    definition:
-      - apiVersion: v1
-        kind: Secret
-        metadata:
-          name: "{{ metrics_server_helm_release_secret_name }}"
-          namespace: "{{ metrics_server_helm_release_namespace }}"
-        type: Opaque
-        stringData:
-          values.yaml: "{{ lookup('atmosphere.common.helm_values', 'metrics_server') }}"
+  kubernetes.core.helm_info:
+    name: "{{ metrics_server_helm_release_name }}"
+    namespace: "{{ metrics_server_helm_release_namespace }}"
+    release_state: all
+  register: metrics_server_helm_info
+
+- name: Set final version for chart values
+  run_once: true
+  ansible.builtin.set_fact:
+    metrics_server_final_helm_values: "{{ lookup('atmosphere.common.helm_values', 'metrics_server', (metrics_server_helm_info.status['values'] | default({}))) }}" # noqa: yaml[line-length]
 
 - name: Install "metrics-server"
   run_once: true
@@ -25,6 +25,15 @@
         kind: Namespace
         metadata:
           name: "{{ metrics_server_helm_release_namespace }}"
+
+      - apiVersion: v1
+        kind: Secret
+        metadata:
+          name: "{{ metrics_server_helm_release_secret_name }}"
+          namespace: "{{ metrics_server_helm_release_namespace }}"
+        type: Opaque
+        stringData:
+          values.yaml: "{{ metrics_server_final_helm_values }}"
 
       - apiVersion: source.toolkit.fluxcd.io/v1
         kind: HelmRepository
@@ -41,11 +50,9 @@
           name: "{{ metrics_server_helm_release_name }}"
           namespace: "{{ metrics_server_helm_release_namespace }}"
           annotations:
-            reconcile.fluxcd.io/requestedAt: "{{ lookup('atmosphere.common.helm_values', 'metrics_server') | checksum }}"
-            reconcile.fluxcd.io/forceAt: "{{ lookup('atmosphere.common.helm_values', 'metrics_server') | checksum }}"
+            reconcile.fluxcd.io/requestedAt: "{{ metrics_server_final_helm_values | checksum }}"
         spec:
-          interval: 5m
-          timeout: 5m
+          interval: 10m
           releaseName: "{{ metrics_server_helm_release_name }}"
           chart:
             spec:

--- a/roles/metrics_server/tasks/main.yaml
+++ b/roles/metrics_server/tasks/main.yaml
@@ -22,11 +22,22 @@
           interval: 60m
           url: "{{ metrics_server_helm_repository_url }}"
 
+      - apiVersion: v1
+        kind: Secret
+        metadata:
+          name: "{{ metrics_server_helm_release_secret_name }}"
+          namespace: "{{ metrics_server_helm_release_namespace }}"
+        type: Opaque
+        stringData:
+          values.yaml: "{{ lookup('atmosphere.common.helm_values', 'metrics_server') }}"
+
       - apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: "{{ metrics_server_helm_release_name }}"
           namespace: "{{ metrics_server_helm_release_namespace }}"
+          annotations:
+            reconcile.fluxcd.io/requestedAt: "{{ lookup('atmosphere.common.helm_values', 'metrics_server') | checksum }}"
         spec:
           interval: 10m
           releaseName: "{{ metrics_server_helm_release_name }}"
@@ -37,4 +48,6 @@
               sourceRef:
                 kind: HelmRepository
                 name: "{{ metrics_server_helm_repository_name }}"
-          values: "{{ _metrics_server_helm_values | combine(metrics_server_helm_values, recursive=True) }}"
+          valuesFrom:
+            - kind: Secret
+              name: "{{ metrics_server_helm_release_secret_name }}"


### PR DESCRIPTION
The issue https://github.com/fluxcd/kustomize-controller/issues/372
causes issues for users when trying to change values since they must
be nulled in order to "wipe" their value.

This instead circumvents this issue by referencing the values from
a secret (which can also help with RBAC control not making the
information visible in the custom resource directly).

Signed-off-by: Mohammed Naser <mnaser@vexxhost.com>
