### PR TITLE
refactor: migrate from Flux to direct Helm deployments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,14 +42,7 @@ jobs:
           uv run ansible-playbook \
             --connection=local \
             --extra-vars target=localhost \
-              atmosphere.common.flux \
               atmosphere.common.cert_manager
-      - run: |
-          kubectl wait \
-            --namespace cert-manager \
-            --for=condition=ready \
-            --timeout=5m \
-            helmrelease/cert-manager
       - run: |
           kubectl wait \
             --namespace cert-manager \
@@ -114,14 +107,7 @@ jobs:
           uv run ansible-playbook \
             --connection=local \
             --extra-vars target=localhost \
-              atmosphere.common.flux \
               atmosphere.common.dellhw_exporter
-      - run: |
-          kubectl wait \
-            --namespace monitoring \
-            --for=condition=ready \
-            --timeout=5m \
-            helmrelease/prometheus-dellhw-exporter
       - run: |
           kubectl wait \
             --namespace monitoring \
@@ -136,20 +122,11 @@ jobs:
       - uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
       - uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
       - run: uv run ansible-galaxy collection install ${{ github.workspace }}
-      - name: Apply metrics-server HelmRelease
-        run: |
+      - run: |
           uv run ansible-playbook \
             --connection=local \
             --extra-vars target=localhost \
-              atmosphere.common.flux \
               atmosphere.common.metrics_server
-      - name: Wait for metrics-server HelmRelease to be ready
-        run: |
-          kubectl wait \
-            --namespace kube-system \
-            --for=condition=ready \
-            --timeout=5m \
-            helmrelease/metrics-server
       - name: Wait for Metrics Server to be ready
         run: |
           kubectl wait \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,7 @@ jobs:
           uv run ansible-playbook \
             --connection=local \
             --extra-vars target=localhost \
+            --extra-vars kubeconfig_path=$HOME/.kube/config \
               atmosphere.common.cert_manager
       - run: |
           kubectl wait \
@@ -63,6 +64,7 @@ jobs:
           uv run ansible-playbook \
             --connection=local \
             --extra-vars target=localhost \
+            --extra-vars kubeconfig_path=$HOME/.kube/config \
             --extra-vars ironic_standalone_ip_address=172.18.0.2 \
             --extra-vars ironic_standalone_dhcp_cidr=172.18.0.0/24 \
             --extra-vars ironic_standalone_dhcp_range_start=172.18.0.10 \
@@ -107,6 +109,7 @@ jobs:
           uv run ansible-playbook \
             --connection=local \
             --extra-vars target=localhost \
+            --extra-vars kubeconfig_path=$HOME/.kube/config \
               atmosphere.common.dellhw_exporter
       - run: |
           kubectl wait \
@@ -126,6 +129,7 @@ jobs:
           uv run ansible-playbook \
             --connection=local \
             --extra-vars target=localhost \
+            --extra-vars kubeconfig_path=$HOME/.kube/config \
               atmosphere.common.metrics_server
       - name: Wait for Metrics Server to be ready
         run: |

--- a/roles/cert_manager/defaults/main.yaml
+++ b/roles/cert_manager/defaults/main.yaml
@@ -1,13 +1,13 @@
 # Copyright (c) 2025 VEXXHOST, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-cert_manager_helm_repository_name: jetstack
 cert_manager_helm_repository_url: https://charts.jetstack.io
 cert_manager_helm_chart_name: cert-manager
 cert_manager_helm_chart_version: 1.17.2
 
 cert_manager_helm_release_namespace: cert-manager
 cert_manager_helm_release_name: cert-manager
+cert_manager_helm_kubeconfig: "{{ kubeconfig_path | default('/etc/kubernetes/admin.conf') }}"
 
 cert_manager_helm_values: {}
 cert_manager_node_selector: {}

--- a/roles/cert_manager/tasks/main.yaml
+++ b/roles/cert_manager/tasks/main.yaml
@@ -1,40 +1,14 @@
 # Copyright (c) 2025 VEXXHOST, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-- name: Install "cert-manager"
+- name: Deploy Helm chart
   run_once: true
-  kubernetes.core.k8s:
-    server_side_apply:
-      field_manager: "atmosphere.common"
-      force_conflicts: true
-    definition:
-      - apiVersion: v1
-        kind: Namespace
-        metadata:
-          name: "{{ cert_manager_helm_release_namespace }}"
-
-      - apiVersion: source.toolkit.fluxcd.io/v1
-        kind: HelmRepository
-        metadata:
-          name: "{{ cert_manager_helm_repository_name }}"
-          namespace: "{{ cert_manager_helm_release_namespace }}"
-        spec:
-          interval: 5m
-          url: "{{ cert_manager_helm_repository_url }}"
-
-      - apiVersion: helm.toolkit.fluxcd.io/v2
-        kind: HelmRelease
-        metadata:
-          name: "{{ cert_manager_helm_release_name }}"
-          namespace: "{{ cert_manager_helm_release_namespace }}"
-        spec:
-          interval: 10m
-          releaseName: "{{ cert_manager_helm_release_name }}"
-          chart:
-            spec:
-              chart: "{{ cert_manager_helm_chart_name }}"
-              version: "{{ cert_manager_helm_chart_version }}"
-              sourceRef:
-                kind: HelmRepository
-                name: "{{ cert_manager_helm_repository_name }}"
-          values: "{{ _cert_manager_helm_values | combine(cert_manager_helm_values, recursive=True) }}"
+  kubernetes.core.helm:
+    name: "{{ cert_manager_helm_release_name }}"
+    chart_repo_url: "{{ cert_manager_helm_repository_url }}"
+    chart_ref: "{{ cert_manager_helm_chart_name }}"
+    chart_version: "{{ cert_manager_helm_chart_version }}"
+    release_namespace: "{{ cert_manager_helm_release_namespace }}"
+    create_namespace: true
+    kubeconfig: "{{ cert_manager_helm_kubeconfig }}"
+    values: "{{ _cert_manager_helm_values | combine(cert_manager_helm_values, recursive=True) }}"

--- a/roles/dellhw_exporter/defaults/main.yaml
+++ b/roles/dellhw_exporter/defaults/main.yaml
@@ -1,13 +1,13 @@
 # Copyright (c) 2025 VEXXHOST, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-dellhw_exporter_helm_repository_name: prometheus-dellhw-exporter
 dellhw_exporter_helm_repository_url: https://galexrt.github.io/dellhw_exporter
 dellhw_exporter_helm_chart_name: prometheus-dellhw-exporter
 dellhw_exporter_helm_chart_version: 1.0.3
 
 dellhw_exporter_helm_release_namespace: monitoring
 dellhw_exporter_helm_release_name: prometheus-dellhw-exporter
+dellhw_exporter_helm_kubeconfig: "{{ kubeconfig_path | default('/etc/kubernetes/admin.conf') }}"
 
 dellhw_exporter_helm_values: {}
 

--- a/roles/dellhw_exporter/tasks/main.yaml
+++ b/roles/dellhw_exporter/tasks/main.yaml
@@ -1,40 +1,14 @@
 # Copyright (c) 2025 VEXXHOST, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-- name: Install "dellhw_exporter"
+- name: Deploy Helm chart
   run_once: true
-  kubernetes.core.k8s:
-    server_side_apply:
-      field_manager: "atmosphere.common"
-      force_conflicts: true
-    definition:
-      - apiVersion: v1
-        kind: Namespace
-        metadata:
-          name: "{{ dellhw_exporter_helm_release_namespace }}"
-
-      - apiVersion: source.toolkit.fluxcd.io/v1
-        kind: HelmRepository
-        metadata:
-          name: "{{ dellhw_exporter_helm_repository_name }}"
-          namespace: "{{ dellhw_exporter_helm_release_namespace }}"
-        spec:
-          interval: 60m
-          url: "{{ dellhw_exporter_helm_repository_url }}"
-
-      - apiVersion: helm.toolkit.fluxcd.io/v2
-        kind: HelmRelease
-        metadata:
-          name: "{{ dellhw_exporter_helm_release_name }}"
-          namespace: "{{ dellhw_exporter_helm_release_namespace }}"
-        spec:
-          interval: 10m
-          releaseName: "{{ dellhw_exporter_helm_release_name }}"
-          chart:
-            spec:
-              chart: "{{ dellhw_exporter_helm_chart_name }}"
-              version: "{{ dellhw_exporter_helm_chart_version }}"
-              sourceRef:
-                kind: HelmRepository
-                name: "{{ dellhw_exporter_helm_repository_name }}"
-          values: "{{ _dellhw_exporter_helm_values | combine(dellhw_exporter_helm_values, recursive=True) }}"
+  kubernetes.core.helm:
+    name: "{{ dellhw_exporter_helm_release_name }}"
+    chart_repo_url: "{{ dellhw_exporter_helm_repository_url }}"
+    chart_ref: "{{ dellhw_exporter_helm_chart_name }}"
+    chart_version: "{{ dellhw_exporter_helm_chart_version }}"
+    release_namespace: "{{ dellhw_exporter_helm_release_namespace }}"
+    create_namespace: true
+    kubeconfig: "{{ dellhw_exporter_helm_kubeconfig }}"
+    values: "{{ _dellhw_exporter_helm_values | combine(dellhw_exporter_helm_values, recursive=True) }}"

--- a/roles/metrics_server/defaults/main.yaml
+++ b/roles/metrics_server/defaults/main.yaml
@@ -1,13 +1,13 @@
 # Copyright (c) 2025 VEXXHOST, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-metrics_server_helm_repository_name: metrics-server
 metrics_server_helm_repository_url: https://kubernetes-sigs.github.io/metrics-server
 metrics_server_helm_chart_name: metrics-server
 metrics_server_helm_chart_version: 3.12.2
 
 metrics_server_helm_release_namespace: kube-system
 metrics_server_helm_release_name: metrics-server
+metrics_server_helm_kubeconfig: "{{ kubeconfig_path | default('/etc/kubernetes/admin.conf') }}"
 
 metrics_server_helm_values: {}
 

--- a/roles/metrics_server/tasks/main.yaml
+++ b/roles/metrics_server/tasks/main.yaml
@@ -1,40 +1,14 @@
 # Copyright (c) 2025 VEXXHOST, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-- name: Install "metrics-server"
+- name: Deploy Helm chart
   run_once: true
-  kubernetes.core.k8s:
-    server_side_apply:
-      field_manager: "atmosphere.common"
-      force_conflicts: true
-    definition:
-      - apiVersion: v1
-        kind: Namespace
-        metadata:
-          name: "{{ metrics_server_helm_release_namespace }}"
-
-      - apiVersion: source.toolkit.fluxcd.io/v1
-        kind: HelmRepository
-        metadata:
-          name: "{{ metrics_server_helm_repository_name }}"
-          namespace: "{{ metrics_server_helm_release_namespace }}"
-        spec:
-          interval: 60m
-          url: "{{ metrics_server_helm_repository_url }}"
-
-      - apiVersion: helm.toolkit.fluxcd.io/v2
-        kind: HelmRelease
-        metadata:
-          name: "{{ metrics_server_helm_release_name }}"
-          namespace: "{{ metrics_server_helm_release_namespace }}"
-        spec:
-          interval: 10m
-          releaseName: "{{ metrics_server_helm_release_name }}"
-          chart:
-            spec:
-              chart: "{{ metrics_server_helm_chart_name }}"
-              version: "{{ metrics_server_helm_chart_version }}"
-              sourceRef:
-                kind: HelmRepository
-                name: "{{ metrics_server_helm_repository_name }}"
-          values: "{{ _metrics_server_helm_values | combine(metrics_server_helm_values, recursive=True) }}"
+  kubernetes.core.helm:
+    name: "{{ metrics_server_helm_release_name }}"
+    chart_repo_url: "{{ metrics_server_helm_repository_url }}"
+    chart_ref: "{{ metrics_server_helm_chart_name }}"
+    chart_version: "{{ metrics_server_helm_chart_version }}"
+    release_namespace: "{{ metrics_server_helm_release_namespace }}"
+    create_namespace: true
+    kubeconfig: "{{ metrics_server_helm_kubeconfig }}"
+    values: "{{ _metrics_server_helm_values | combine(metrics_server_helm_values, recursive=True) }}"


### PR DESCRIPTION
## Summary
- Replace Flux HelmRelease resources with direct kubernetes.core.helm module calls
- Simplify deployment process by removing Flux dependency
- Update CI workflows to remove Flux-specific wait conditions

## Test plan
- [ ] CI tests pass for cert-manager deployment
- [ ] CI tests pass for dellhw-exporter deployment  
- [ ] CI tests pass for metrics-server deployment
- [ ] Verify Helm charts deploy successfully without Flux

🤖 Generated with [Claude Code](https://claude.ai/code)